### PR TITLE
Compassionate Leave

### DIFF
--- a/src/Domain.fs
+++ b/src/Domain.fs
@@ -98,7 +98,7 @@ type AbsencePolicy =
         | WorkingFromHome -> "WFH"
         | Sick -> "Sick Leave"
         | Appointment -> "Appointment"
-        | CompassionateLeave -> "Compassionate Leave"
+        | CompassionateLeave -> "Leave"
         | UnpaidLeave -> "Unpaid Leave"
         | Conference -> "Conference"
         | Training -> "Training"

--- a/tests/TodaysAbsences.Tests/BobApiResponseParsingTests.fs
+++ b/tests/TodaysAbsences.Tests/BobApiResponseParsingTests.fs
@@ -83,7 +83,7 @@ let tests =
                             {
                                 "employeeId": "1",
                                 "policyType": "type1",
-                                "policyTypeDisplayName": "Holiday",
+                                "policyTypeDisplayName": "Compassionate Leave",
                                 "requestId": 1,
                                 "status": "approved",
                                 "employeeDisplayName": "Bugs Bunny",
@@ -101,7 +101,7 @@ let tests =
                                    Department = Department.Other; 
                                    Squad = None;
                                    Id = "1" |> EmployeeId }
-                      Details = { Policy = AbsencePolicy.Holiday; 
+                      Details = { Policy = AbsencePolicy.CompassionateLeave; 
                                   Duration = PartOfDay Afternoon } } ]
 
                 getAbsences testContext absences details

--- a/tests/TodaysAbsences.Tests/SlackMessageBuildingTests.fs
+++ b/tests/TodaysAbsences.Tests/SlackMessageBuildingTests.fs
@@ -21,7 +21,16 @@ let private emptyEmployeeDetails =
           Department = "" }
       Personal =
         { ShortBirthDate = "" }
-      Id = "" }
+      Id = ""
+      HumanReadable = {
+          Work = {
+            Custom = 
+                { Squad_5Gqot = None }
+            Department = "" }       
+      }
+    }
+    
+    
 
 [<Tests>]
 let tests =

--- a/tests/TodaysAbsences.Tests/SlackMessageBuildingTests.fs
+++ b/tests/TodaysAbsences.Tests/SlackMessageBuildingTests.fs
@@ -69,12 +69,12 @@ let tests =
                                    Department = Department.Tech; 
                                    Squad = None;
                                    Id = "" |> EmployeeId }
-                      Details = { Policy = AbsencePolicy.Holiday; 
+                      Details = { Policy = AbsencePolicy.CompassionateLeave; 
                                   Duration = Days 4m }
                     }
                 ]
                 let expected = [
-                    Block.section "*Tech*\nJoe Bloggs - Holiday - 4 days"
+                    Block.section "*Tech*\nJoe Bloggs - Leave - 4 days"
                 ]
 
                 Expect.sequenceEqual "" (absenceBlocks absences) expected


### PR DESCRIPTION
Sandy has asked me to change how we display Compassionate Leave.
She would like us to just display it as "Leave" in our daily Slack update.