### PR TITLE
Add Product Design Department

### DIFF
--- a/src/Domain.fs
+++ b/src/Domain.fs
@@ -25,6 +25,7 @@ type Department =
     | LegalAndCompliance
     | Operations
     | StrategicOperations
+    | ProductDesign
     | Other
 
     static member unwrap = 
@@ -39,6 +40,7 @@ type Department =
         | LegalAndCompliance -> "Legal & Compliance"
         | Operations -> "Operations"
         | StrategicOperations -> "Strategic Operations"
+        | Product -> "Product Design"
         | Other -> "Other"
     
     static member create = 
@@ -54,6 +56,7 @@ type Department =
         | "Legal & Compliance" -> LegalAndCompliance
         | "Operations" -> Operations
         | "Strategic Operations" -> StrategicOperations
+        | "Product Design" -> ProductDesign
         | x -> printf "Other department: %s" x
                Other
 

--- a/src/Domain.fs
+++ b/src/Domain.fs
@@ -40,7 +40,7 @@ type Department =
         | LegalAndCompliance -> "Legal & Compliance"
         | Operations -> "Operations"
         | StrategicOperations -> "Strategic Operations"
-        | Product -> "Product Design"
+        | ProductDesign -> "Product Design"
         | Other -> "Other"
     
     static member create = 


### PR DESCRIPTION
The Product Design department has been added to Bob.
In this PR I've added the appropriate mapping to display the department correctly on our daily Slack message.