### PR TITLE
Fix: Sick Leave Parsing

### DIFF
--- a/src/Domain.fs
+++ b/src/Domain.fs
@@ -1,6 +1,7 @@
 module Domain
 
 open System
+open System.Text.RegularExpressions
 open BobApi
 open Dto
 open Helpers
@@ -116,7 +117,6 @@ type AbsencePolicy =
         function
         | "Holiday" -> Holiday
         | "WFH" -> WorkingFromHome
-        | "Sick Leave" -> Sick
         | "Appointment" -> Appointment
         | "Compassionate Leave" -> CompassionateLeave
         | "Unpaid Leave" -> UnpaidLeave
@@ -127,6 +127,7 @@ type AbsencePolicy =
         | "Maternity Leave" -> MaternityLeave
         | "Working Abroad" -> WorkingAbroad
         | "Study Leave" -> StudyLeave
+        | Regex @"sick" RegexOptions.IgnoreCase [] -> Sick
         | _ -> Other
 
 type PartOfDay = Morning | Afternoon | AllDay

--- a/src/Domain.fs
+++ b/src/Domain.fs
@@ -116,7 +116,7 @@ type AbsencePolicy =
         function
         | "Holiday" -> Holiday
         | "WFH" -> WorkingFromHome
-        | "Sick" -> Sick
+        | "Sick Leave" -> Sick
         | "Appointment" -> Appointment
         | "Compassionate Leave" -> CompassionateLeave
         | "Unpaid Leave" -> UnpaidLeave

--- a/src/TypeExtensions.fs
+++ b/src/TypeExtensions.fs
@@ -2,10 +2,16 @@
 module TypeExtensions
 
 open System
+open System.Text.RegularExpressions
 
 let tee f x =
     f x
     x
+    
+let (|Regex|_|) pattern options input =
+   let m = Regex.Match(input, pattern, options)
+   if m.Success then Some(List.tail [ for g in m.Groups -> g.Value ])
+   else None
 
 module Result =
     let retn x = Ok x

--- a/tests/TodaysAbsences.Tests/BobApiResponseParsingTests.fs
+++ b/tests/TodaysAbsences.Tests/BobApiResponseParsingTests.fs
@@ -46,7 +46,7 @@ let tests =
                             {
                                 "employeeId": "1",
                                 "policyType": "type1",
-                                "policyTypeDisplayName": "Holiday",
+                                "policyTypeDisplayName": "Sick Leave",
                                 "requestId": 1,
                                 "status": "approved",
                                 "employeeDisplayName": "Bugs Bunny",
@@ -64,7 +64,7 @@ let tests =
                                    Department = Department.Other; 
                                    Squad = None;
                                    Id = "1" |> EmployeeId }
-                      Details = { Policy = AbsencePolicy.Holiday; 
+                      Details = { Policy = AbsencePolicy.Sick; 
                                   Duration = Days 1m } } ]
 
                 

--- a/tests/TodaysAbsences.Tests/BobApiResponseParsingTests.fs
+++ b/tests/TodaysAbsences.Tests/BobApiResponseParsingTests.fs
@@ -242,7 +242,7 @@ let tests =
                             {
                                 "employeeId": "1",
                                 "policyType": "type1",
-                                "policyTypeDisplayName": "Holiday",
+                                "policyTypeDisplayName": "Sick",
                                 "requestId": 1,
                                 "status": "approved",
                                 "employeeDisplayName": "Bugs Bunny",
@@ -260,7 +260,7 @@ let tests =
                                    Department = Department.Other; 
                                    Squad = None;
                                    Id = "1" |> EmployeeId }
-                      Details = { Policy = AbsencePolicy.Holiday; 
+                      Details = { Policy = AbsencePolicy.Sick; 
                                   Duration = PartOfDay Afternoon } } ]
                 
                 getAbsences testContext absences details

--- a/tests/TodaysAbsences.Tests/SlackMessageBuildingTests.fs
+++ b/tests/TodaysAbsences.Tests/SlackMessageBuildingTests.fs
@@ -17,20 +17,12 @@ let private emptyEmployeeDetails =
     { FullName = ""
       Work = 
         { Custom = 
-            { Squad_5Gqot = None }
+            Some { Squad_5Gqot = None }
           Department = "" }
       Personal =
         { ShortBirthDate = "" }
       Id = ""
-      HumanReadable = {
-          Work = {
-            Custom = 
-                { Squad_5Gqot = None }
-            Department = "" }       
-      }
     }
-    
-    
 
 [<Tests>]
 let tests =


### PR DESCRIPTION
As a result of either: using the human readable flag, or Bob deciding to change values, the Sick Leave policy is not parsing correctly.
I checked the response from the Bob Api Endpoint, and found that for the policyType the value `Sick` is now `Sick Leave`.
I've added a fix and a test, and manually tested in stage.